### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/Springworks/node-mongoose-test-marker/badge.png)](https://coveralls.io/r/Springworks/node-mongoose-test-marker)
 [![Build Status](https://travis-ci.org/Springworks/node-mongoose-test-marker.svg?branch=master)](https://travis-ci.org/Springworks/node-mongoose-test-marker)
 [![Dependency Status](https://david-dm.org/springworks/node-mongoose-test-marker.svg)](https://david-dm.org/springworks/node-mongoose-test-marker)
+[![Inline docs](http://inch-ci.org/github/Springworks/node-mongoose-test-marker.svg?branch=master)](http://inch-ci.org/github/Springworks/node-mongoose-test-marker)
 
 ## 1.0.x API Reference
 * [Introduction](#introduction "Introduction")


### PR DESCRIPTION
Hi there,

you have recently tried to evaluate this project via Inch. I took the liberty to make a badge for you: [![Inline docs](http://inch-ci.org/github/Springworks/node-mongoose-test-marker.svg)](http://inch-ci.org/github/Springworks/node-mongoose-test-marker)


The badge shows an evaluation by [InchJS](http://trivelop.de/inchjs), but I guess you already knew that. :wink: 

I would really like to roll out support for JS over the coming weeks (early adopters are [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [Shipit](https://github.com/shipitjs/shipit)).

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/Springworks/node-mongoose-test-marker

What do you think?